### PR TITLE
Simplify starting kit to pass tests

### DIFF
--- a/problem.py
+++ b/problem.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import pandas as pd
 import rampwf as rw
 from sklearn.model_selection import StratifiedShuffleSplit
@@ -37,6 +38,10 @@ def _read_data(path, f_name):
 
     y_array = data['label'].values
     X_df = data.drop([_target_column_name] + _ignore_column_names, axis=1)
+
+    if pd.isnull(y_array).any():
+        raise ValueError('Failed to read {}, nan detected in y_array'
+                         .format(f_name))
 
     return X_df, y_array
 

--- a/submissions/starting_kit/feature_extractor.py
+++ b/submissions/starting_kit/feature_extractor.py
@@ -3,6 +3,7 @@
 import numpy as np
 import string, unicodedata
 
+import pandas as pd
 from nltk.corpus import stopwords
 from nltk import word_tokenize
 from nltk.stem import SnowballStemmer
@@ -43,6 +44,14 @@ def strip_accents_unicode(s):
     s = s.decode("utf-8")
     return str(s)
 
+
+def _clean_statement_nan(statement):
+    statement = statement.copy()
+    mask = pd.isnull(statement)
+    statement[mask] = ''
+    return statement
+
+
 class FeatureExtractor(TfidfVectorizer):
     """Convert a collection of raw documents to a matrix of TF-IDF features.
 
@@ -74,28 +83,30 @@ class FeatureExtractor(TfidfVectorizer):
         -------
         self
         """
-        self._feat = np.array([' '.join(clean_str(text.strip_accents_unicode(dd))) 
-                    for dd in X_df.statement])
+        #self._feat = np.array([' '.join(clean_str(text.strip_accents_unicode(dd)))
+        #            for dd in X_df.statement])
+        self._feat = True
+        statement = _clean_statement_nan(X_df.statement)
 
-        
-        super(FeatureExtractor, self).fit(self._feat)
+        super(FeatureExtractor, self).fit(statement)
 
         return self
         
     def fit_transform(self, X_df, y=None):
         
         self.fit(X_df)
+        statement = _clean_statement_nan(X_df.statement)
 
-        return self.transform(self.X_df)
+        return self.transform(statement)
         
     def transform(self, X_df):
         
-        X = np.array([' '.join(clean_str(text.strip_accents_unicode(dd))) 
-                    for dd in X_df.statement])
+        #X = np.array([' '.join(clean_str(text.strip_accents_unicode(dd))) 
+        #            for dd in X_df.statement])
 
         check_is_fitted(self, '_feat', 'The tfidf vector is not fitted')
+        statement = _clean_statement_nan(X_df.statement)
 
-        X = super(FeatureExtractor, self).transform(X)
-                
+        X = super(FeatureExtractor, self).transform(statement)
+
         return X
-


### PR DESCRIPTION
This adds a few changes aiming to make the tests pass.  This
 *  bypasses all the advanced feature extraction, using the `TfdfVectorizer` directly
 *  raise an explicit error when the `test.csv` cannot be properly loaded.

Currently, at least on my laptop tests fails for the `pep8` branch because `test.csv` is not correctly formatted. It is expected to be tab separated, but is space separated, unlike the `train.csv`. Since it also contains other space separated text it is not working so well.

Tests still fail, but hopefully it's a step toward passing them. Also, I have not done anything about pep8 or removing not used function.

PR made into the `pep8` @kegl 's branch, following discussion in https://github.com/ramp-kits/fake_news/commit/58c9c0bba49215b2cc761b04cc6f1dfbcf301034#commitcomment-25177023